### PR TITLE
fix_token_3.3.4

### DIFF
--- a/includes/token.php
+++ b/includes/token.php
@@ -92,6 +92,7 @@ class token
             $TokenB = trim((string)$TokenB);
             if ($tokenA == $TokenB )
             {
+                $this->resetInCookie();
                 return true;
             }
         }
@@ -153,9 +154,16 @@ class token
 
     private function resetInCookie()
     {
+        global $_COOKIE ;
         if (isset($_SESSION['ogspy_token']))
         {
             unset($_SESSION['ogspy_token']);
+        }
+        //old plugin token (3.3.4)
+        if (isset($_COOKIE["token"]))
+        {
+            unset($_COOKIE['token']);
+            setcookie("token", $_COOKIE["token"],time()-1);
         }
     }
 


### PR DESCRIPTION
suppression du token stocké dans coockie
provoquant un écrasement des variables ($pub_)