### PR TITLE
Allow OGspy to work with missing translations

### DIFF
--- a/lang/lang_main.php
+++ b/lang/lang_main.php
@@ -9,29 +9,48 @@
  * @version 3.3.0
  */
 
+function load_lang_file($ui_lang, $filename, $parent_dir = ".") {
+    global $lang;
+    if(empty($lang)) {
+        $lang = array();       
+    }
+    $default_language = 'fr';
+    $file_path = $parent_dir . "/lang/" . $ui_lang . "/" . $filename;
+    $default_file_path = $parent_dir . "/lang/" . $default_language . "/" . $filename;
+    if (file_exists($file_path)) {
+        require_once ($file_path);
+        return;
+    }
+    trigger_error($file_path . " does not exist! Please consider helping with the translation!", E_USER_WARNING);
+    trigger_error("Loading " . $default_file_path, E_USER_WARNING);
+    require_once ($default_file_path);
+}
+
+global $lang = [];
+
 if (defined("INSTALL_IN_PROGRESS") || defined("UPGRADE_IN_PROGRESS")) {
-    require_once ("../lang/" . $ui_lang . "/lang_install.php");
-    require_once ("../lang/" . $ui_lang . "/lang_help.php");
+    load_lang_file($ui_lang, "lang_install.php", "..");
+    load_lang_file($ui_lang, "lang_help.php", "..");
 } else
 {
-    require_once ("./lang/" . $ui_lang . "/lang_about.php");
-    require_once ("./lang/" . $ui_lang . "/lang_admin.php");
-    require_once ("./lang/" . $ui_lang . "/lang_cartography.php");
-    require_once ("./lang/" . $ui_lang . "/lang_galaxy.php");
-    require_once ("./lang/" . $ui_lang . "/lang_game.php");
-    require_once ("./lang/" . $ui_lang . "/lang_header_tail.php");
-    require_once ("./lang/" . $ui_lang . "/lang_help.php");
-    require_once ("./lang/" . $ui_lang . "/lang_home.php");
-    require_once ("./lang/" . $ui_lang . "/lang_login.php");
-    require_once ("./lang/" . $ui_lang . "/lang_mail.php");
-    require_once ("./lang/" . $ui_lang . "/lang_menu.php");
-    require_once ("./lang/" . $ui_lang . "/lang_message.php");
-    require_once ("./lang/" . $ui_lang . "/lang_profile.php");
-    require_once ("./lang/" . $ui_lang . "/lang_ranking.php");
-    require_once ("./lang/" . $ui_lang . "/lang_report.php");
-    require_once ("./lang/" . $ui_lang . "/lang_search.php");
-    require_once ("./lang/" . $ui_lang . "/lang_serverdown.php");
-    require_once ("./lang/" . $ui_lang . "/lang_statistic.php");
+    load_lang_file($ui_lang, "lang_about.php");
+    load_lang_file($ui_lang, "lang_admin.php");
+    load_lang_file($ui_lang, "lang_cartography.php");
+    load_lang_file($ui_lang, "lang_galaxy.php");
+    load_lang_file($ui_lang, "lang_game.php");
+    load_lang_file($ui_lang, "lang_header_tail.php");
+    load_lang_file($ui_lang, "lang_help.php");
+    load_lang_file($ui_lang, "lang_home.php");
+    load_lang_file($ui_lang, "lang_login.php");
+    load_lang_file($ui_lang, "lang_mail.php");
+    load_lang_file($ui_lang, "lang_menu.php");
+    load_lang_file($ui_lang, "lang_message.php");
+    load_lang_file($ui_lang, "lang_profile.php");
+    load_lang_file($ui_lang, "lang_ranking.php");
+    load_lang_file($ui_lang, "lang_report.php");
+    load_lang_file($ui_lang, "lang_search.php");
+    load_lang_file($ui_lang, "lang_serverdown.php");
+    load_lang_file($ui_lang, "lang_statistic.php");
 }
 
 


### PR DESCRIPTION
Until now, if a language file was missing for a language, OGspy just crashed and showed a fatal error at the web server logs.

I think it is too radical, so this patch will load the french language files if those for the UI interface are not found.

It will also print PHP warnings to the log server about it:

> 2019-04-06 21:12:28: (mod_fastcgi.c.434) FastCGI-stderr: PHP Warning:  ./lang/es/lang_mail.php does not exist! Please consider helping with the translation! in /var/www/localhost/htdocs/lang/lang_main.php on line 20
> 2019-04-06 21:12:28: (mod_fastcgi.c.434) FastCGI-stderr: PHP Warning:  Loading ./lang/fr/lang_mail.php in /var/www/localhost/htdocs/lang/lang_main.php on line 21

The code works, but it's more than 15 years since the last time I did something with PHP, and to be honest I am still not familiar with OGspy code, so add as many comments and request to change stuff as needed.