### PR TITLE
ajustement largeur menu pour éviter les sauts de lignes

### DIFF
--- a/views/menu.php
+++ b/views/menu.php
@@ -95,7 +95,7 @@ if (!defined('IN_SPYOGAME')) {
         <td>
             <div style="text-align='left';">
 
-                <ul style="width:100px;" class="menu" id="menu">
+                <ul class="menu" id="menu">
                     <?php
                     if ($user_data["user_admin"] == 1 || $user_data["user_coadmin"] == 1 || $user_data["management_user"] == 1) {
                         echo "<li><a href='index.php?action=administration' class='menu_items'>" . $lang['MENU_ADMIN'] . "</a></li>";


### PR DESCRIPTION
Je voulais à la base raccourcir l'intitulé de Champ de ruine, puis je me suis rendu compte que le problème était ailleurs.

Le menu est limité en largeur par son conteneur parent, il n'y a donc pas de risque de voir le menu prendre plus de largeur si des intitulés étaient long. Or, il y a une limite supplémentaire de 100px de large. Elle provoque des sauts de lignes dans les noms des mods et l'espace personnel. En retirant cette limite, tout les sauts de lignes que j'ai constaté disparaissent.

Voir image avant/après ci-dessous.

![ogspy-menu](https://user-images.githubusercontent.com/61603453/75631189-00fc4480-5bf1-11ea-85fe-cebf5c3c67a4.png)