### PR TITLE
Add application version update to auto-upgrade process

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@ global $server_config, $ogspy_version, $user_data, $log, $db; // ajout de $db
 ob_start();
 session_start();
 /**
- * Fichier principal d'ogspy
+ * Fichier principal OGSpy
  * @package OGSpy
  * @subpackage main
  * @author Kyser
@@ -33,7 +33,7 @@ require_once "common.php";
  * @name $benchogspy
  */
 $benchogspy = new Ogsteam\Ogspy\Helper\Benchmark_Helper('ogspy');
-$benchogspy->addCustomBench($php_start,microtime(true),"initialisation Ogspy/include" );
+$benchogspy->addCustomBench($php_start, microtime(true), "initialisation Ogspy/include");
 $benchogspy->start();
 //$benchSQL pour temps sql
 
@@ -44,76 +44,72 @@ if (!isset($pub_action)) {
     $pub_action = "";
 }
 
-if (is_file("install/version.php")) {
-    require_once "install/version.php";
-    $log->info("Version logiciel: " . $ogspy_version);
+// Nouveau système : vérification via MigrationManager
+try {
+    require_once "install/MigrationManager.php";
+    require_once "install/AutoUpgradeManager.php";
 
-    // Nouveau système : vérification via MigrationManager
-    try {
-        require_once "install/MigrationManager.php";
-        require_once "install/AutoUpgradeManager.php";
+    global $table_prefix; // s'assurer de l'utilisation du préfixe courant
+    $migrationManager = new MigrationManager($db, $log, $table_prefix ?? null);
+    $pendingMigrations = $migrationManager->getPendingMigrations();
 
-        global $table_prefix; // s'assurer de l'utilisation du préfixe courant
-        $migrationManager = new MigrationManager($db, $log, isset($table_prefix)?$table_prefix:null);
-        $pendingMigrations = $migrationManager->getPendingMigrations();
+    if (!empty($pendingMigrations)) {
+        $log->info("Pending migrations detected: " . count($pendingMigrations));
 
-        if (!empty($pendingMigrations)) {
-            $log->info("Pending migrations detected: " . count($pendingMigrations));
+        $autoUpgrade = new AutoUpgradeManager($db, $log, $table_prefix ?? null);
 
-            $autoUpgrade = new AutoUpgradeManager($db, $log, isset($table_prefix)?$table_prefix:null);
+        // Vérifie si l'auto-upgrade est possible
+        if ($autoUpgrade->canAutoUpgrade()) {
+            $result = $autoUpgrade->checkAndUpgrade();
 
-            // Vérifie si l'auto-upgrade est possible
-            if ($autoUpgrade->canAutoUpgrade()) {
-                $result = $autoUpgrade->checkAndUpgrade();
+            switch ($result['status']) {
+                case 'up_to_date':
+                    $log->info("Database already up to date");
+                    break;
 
-                switch ($result['status']) {
-                    case 'up_to_date':
-                        $log->info("Database already up to date");
-                        break;
+                case 'success':
+                    $log->info("Auto-upgrade successful: " . $result['message']);
+                    $log->info("New DB version: " . $result['version']);
+                    break;
 
-                    case 'success':
-                        $log->info("Auto-upgrade successful: " . $result['message']);
-                        $log->info("New DB version: " . $result['version']);
-                        break;
+                case 'in_progress':
+                    // Une autre requête traite déjà l'upgrade, on attend
+                    sleep(2);
+                    header("Refresh: 3");
+                    echo "<div style='text-align:center; padding:50px;'>";
+                    echo "<h2>Mise à jour en cours...</h2>";
+                    echo "<p>Veuillez patienter, la page se rechargera automatiquement.</p>";
+                    echo "</div>";
+                    exit();
 
-                    case 'in_progress':
-                        // Une autre requête traite déjà l'upgrade, on attend
-                        sleep(2);
-                        header("Refresh: 3");
-                        echo "<div style='text-align:center; padding:50px;'>";
-                        echo "<h2>Mise à jour en cours...</h2>";
-                        echo "<p>Veuillez patienter, la page se rechargera automatiquement.</p>";
-                        echo "</div>";
-                        exit();
-
-                    case 'error':
-                    case 'critical_error':
-                        $log->error("Auto-upgrade failed: " . $result['message']);
-                        // Fallback vers l'installeur manuel
-                        redirection("install/index.php");
-                        break;
-                }
-            } else {
-                $log->warning("Conditions not met for auto-upgrade, redirecting to installer");
-                // Conditions non réunies pour l'auto-upgrade, redirection classique
-                redirection("install/index.php");
+                case 'error':
+                case 'critical_error':
+                    $log->error("Auto-upgrade failed: " . $result['message']);
+                    // Fallback vers l'installeur manuel
+                    redirection("install/index.php");
+                    break;
             }
         } else {
-            $log->debug("No pending migrations");
-
-            // Vérifier si l'installation est complète (fichier de verrouillage)
-            if (!file_exists("install/install.lock")) {
-                $log->warning("Installation not completed (no lock file), redirecting to installer");
-                redirection("install/index.php");
-            }
+            $log->warning("Conditions not met for auto-upgrade, redirecting to installer");
+            // Conditions non réunies pour l'auto-upgrade, redirection classique
+            redirection("install/index.php");
         }
+    } else {
+        $log->debug("No pending migrations");
 
-    } catch (Exception $e) {
-        $log->error("Migration verification error: " . $e->getMessage());
-        // Fallback vers l'installeur manuel en cas d'erreur
-        redirection("install/index.php");
+        // Vérifier si l'installation est complète (fichier de verrouillage)
+        if (!file_exists("install/install.lock")) {
+            $log->warning("Installation not completed (no lock file), redirecting to installer");
+            redirection("install/index.php");
+        }
     }
+
+} catch (Exception $e) {
+    $log->error("Migration verification error: " . $e->getMessage());
+    // Fallback vers l'installeur manuel en cas d'erreur
+    redirection("install/index.php");
 }
+
 
 if (
     isset($server_config["server_active"]) && $server_config["server_active"] == 0
@@ -164,10 +160,10 @@ if (!isset($pub_goto)) {
 
 switch ($pub_action) {
 
-        //----------------------------------------//
-        //--------Connexion---------//
-        //----------------------------------------//
-        //Identification
+    //----------------------------------------//
+    //--------Connexion---------//
+    //----------------------------------------//
+    //Identification
     case "login_web":
         if ($pub_goto == null) {
             user_login();
@@ -176,14 +172,14 @@ switch ($pub_action) {
         }
         break;
 
-        //Déconnexion
+    //Déconnexion
     case "logout":
         user_logout();
         break;
 
-        //----------------------------------------//
-        //---Administration---//
-        //----------------------------------------//
+    //----------------------------------------//
+    //---Administration---//
+    //----------------------------------------//
     case "administration":
         require_once "views/admin.php";
         break;
@@ -209,9 +205,9 @@ switch ($pub_action) {
         admin_raz_ratio();
         break;
 
-        //----------------------------------------//
-        //---Gestion des membres---//
-        //----------------------------------------//
+    //----------------------------------------//
+    //---Gestion des membres---//
+    //----------------------------------------//
     case "home":
         require_once "views/home.php";
         break;
@@ -268,9 +264,9 @@ switch ($pub_action) {
         usergroup_newmember();
         break;
 
-        //----------------------------------------//
-        //--- ---//
-        //----------------------------------------//
+    //----------------------------------------//
+    //--- ---//
+    //----------------------------------------//
     case "galaxy":
         require_once "views/galaxy.php";
         break;
@@ -279,129 +275,129 @@ switch ($pub_action) {
         require_once "views/galaxy_sector.php";
         break;
 
-        //
+    //
     case "show_reportspy":
         require_once "views/report_spy.php";
         break;
 
-        //
+    //
     case "show_reportrc":
         require_once "views/report_rc.php";
         break;
 
-        //
+    //
     case "add_favorite":
         user_add_favorite();
         break;
 
-        //
+    //
     case "del_favorite":
         user_del_favorite();
         break;
 
-        //
+    //
     case "search":
         require_once "views/search.php";
         break;
 
-        //
+    //
     case "cartography":
         require_once "views/cartography.php";
         break;
 
-        //
+    //
     case "statistic":
         require_once "views/statistic.php";
         break;
 
-        //
+    //
     case "ranking":
         require_once "views/ranking.php";
         break;
 
-        //
+    //
     case "drop_ranking":
         galaxy_drop_ranking();
         break;
 
-        //
+    //
     case "about":
         require_once "views/about_ogsteam.php";
         break;
 
-        //
+    //
     case "galaxy_obsolete":
         require_once "views/galaxy_obsolete.php";
         break;
 
-        //
+    //
     case "add_favorite_spy":
         user_add_favorite_spy();
         break;
 
-        //
+    //
     case "del_favorite_spy":
         user_del_favorite_spy();
         break;
 
-        //
+    //
     case "del_spy":
         user_del_spy();
         break;
 
 
 
-        //----------------------------------------//
-        //--- ---//
-        //----------------------------------------//
+    //----------------------------------------//
+    //--- ---//
+    //----------------------------------------//
     case "mod_disable":
         mod_disable();
         break;
 
-        //
+    //
     case "mod_uninstall":
         mod_uninstall();
         break;
 
-        //
+    //
     case "mod_active":
         mod_active();
         break;
 
-        //
+    //
     case "mod_admin":
         mod_admin();
         break;
 
-        //
+    //
     case "mod_normal":
         mod_normal();
         break;
 
-        //
+    //
     case "mod_install":
         mod_install();
         break;
 
-        //
+    //
     case "mod_update":
         mod_update();
         break;
 
 
-        //
+    //
     case "mod_up":
         mod_sort("up");
         break;
 
 
-        //
+    //
     case "mod_down":
         mod_sort("down");
         break;
-        //----------------------------------------//
-        //--- ---//
-        //----------------------------------------//
+    //----------------------------------------//
+    //--- ---//
+    //----------------------------------------//
     case "server_close":
         require_once "views/serverdown.php";
         break;

--- a/install/AutoUpgradeManager.php
+++ b/install/AutoUpgradeManager.php
@@ -1,22 +1,30 @@
 <?php
 
 /**
- * Auto-Upgrade Manager - Mise à jour automatique silencieuse
+ * Auto-Upgrade Manager - Mise à niveau automatique silencieuse
  * @package OGSpy
  * @subpackage install
  */
+
+require_once __DIR__ . '/ConfigGenerator.php';
 
 class AutoUpgradeManager {
     private $migrationManager;
     private $logger;
     private $lockFile;
     private $maxExecutionTime = 60; // 1 minute max
+    private $db;
+    private $tablePrefix;
+    private $targetVersion;
 
-    public function __construct($db, $logger = null, $table_prefix = 'ogspy_') {
+    public function __construct($db, $logger = null, $table_prefix = 'ogspy_', $target_version = null) {
         if (!$logger) {
             throw new InvalidArgumentException("Logger requis pour AutoUpgradeManager");
         }
 
+        $this->db = $db;
+        $this->tablePrefix = $table_prefix;
+        $this->targetVersion = $target_version;
         $this->migrationManager = new MigrationManager($db, $logger, $table_prefix);
         $this->logger = $logger;
         $this->lockFile = dirname(__DIR__) . '/cache/upgrade.lock';
@@ -85,6 +93,11 @@ class AutoUpgradeManager {
                 ];
             }
 
+            // TOUTES LES MIGRATIONS ONT RÉUSSI - Mettre à jour la version applicative
+            if ($this->targetVersion) {
+                $this->updateApplicationVersion($this->targetVersion);
+            }
+
             // Nettoyage du cache
             $this->clearCache();
 
@@ -93,6 +106,9 @@ class AutoUpgradeManager {
 
             $this->logger->info("SUCCÈS: " . count($successful) . " migration(s) réussie(s)");
             $this->logger->info("Nouvelle version DB: {$newVersion}");
+            if ($this->targetVersion) {
+                $this->logger->info("Version applicative mise à jour: {$this->targetVersion}");
+            }
             $this->logger->info("Temps d'exécution: {$executionTime}s");
             $this->logger->info("=== FIN AUTO-UPGRADE ===");
 
@@ -102,6 +118,7 @@ class AutoUpgradeManager {
                 'status' => 'success',
                 'message' => 'Mise à jour automatique réussie',
                 'version' => $newVersion,
+                'app_version' => $this->targetVersion,
                 'migrations_count' => count($successful),
                 'execution_time' => $executionTime
             ];
@@ -117,6 +134,62 @@ class AutoUpgradeManager {
                 'message' => 'Erreur critique lors de la mise à jour',
                 'error' => $e->getMessage()
             ];
+        }
+    }
+
+    /**
+     * Met à jour la version applicative en base de données après le succès des migrations
+     */
+    private function updateApplicationVersion($version) {
+        try {
+            $this->logger->info("=== APPLICATION VERSION UPDATE ===");
+            $this->logger->info("Target version: {$version}");
+
+            // Vérifier la version actuelle avant mise à jour
+            $currentVersionQuery = "SELECT value FROM {$this->tablePrefix}config WHERE name = 'version'";
+            $this->logger->debug("Current version verification query: {$currentVersionQuery}");
+
+            $result = $this->db->sql_query($currentVersionQuery);
+            $currentVersion = null;
+            if ($this->db->sql_numrows($result) > 0) {
+                $row = $this->db->sql_fetch_assoc($result);
+                $currentVersion = $row['value'];
+                $this->logger->info("Current version found: {$currentVersion}");
+            } else {
+                $this->logger->info("No application version found in database (first installation)");
+            }
+
+            // Effectuer la mise à jour via ConfigGenerator
+            $configGenerator = new ConfigGenerator();
+            $this->logger->info("Calling ConfigGenerator->setApplicationVersion()");
+            $configGenerator->setApplicationVersion($this->db, $this->tablePrefix, $version);
+
+            // Vérifier que la mise à jour a bien fonctionné
+            $verificationQuery = "SELECT value FROM {$this->tablePrefix}config WHERE name = 'version'";
+            $this->logger->debug("Post-update verification query: {$verificationQuery}");
+
+            $verificationResult = $this->db->sql_query($verificationQuery);
+            if ($this->db->sql_numrows($verificationResult) > 0) {
+                $verificationRow = $this->db->sql_fetch_assoc($verificationResult);
+                $newVersionInDb = $verificationRow['value'];
+
+                if ($newVersionInDb === $version) {
+                    $this->logger->info("✓ Application version updated successfully: {$currentVersion} → {$newVersionInDb}");
+                } else {
+                    $this->logger->error("✗ Version update failed: expected '{$version}', found '{$newVersionInDb}'");
+                    throw new Exception("Application version was not properly updated");
+                }
+            } else {
+                $this->logger->error("✗ Unable to verify version after update");
+                throw new Exception("Unable to verify application version after update");
+            }
+
+            $this->logger->info("=== END APPLICATION VERSION UPDATE ===");
+
+        } catch (Exception $e) {
+            $this->logger->error("Error during application version update: " . $e->getMessage());
+            $this->logger->error("Stack trace: " . $e->getTraceAsString());
+            throw $e;
         }
     }
 
@@ -186,7 +259,6 @@ class AutoUpgradeManager {
      * Vérifie si les migrations peuvent être exécutées automatiquement
      */
     public function canAutoUpgrade() {
-
         global $server_config;
         // Vérifie les permissions d'écriture
         $cacheDir = dirname(__DIR__) . '/cache';

--- a/install/ConfigGenerator.php
+++ b/install/ConfigGenerator.php
@@ -52,6 +52,26 @@ class ConfigGenerator {
     }
 
     /**
+     * Insère ou met à jour une valeur dans la table de configuration
+     */
+    public function setConfigValue($db, $table_prefix, $name, $value): void
+    {
+        $configTable = $table_prefix . 'config';
+        $sql = "INSERT INTO `{$configTable}` (`name`, `value`) VALUES ('" . $db->sql_escape_string($name) . "', '" . $db->sql_escape_string($value) . "')
+                ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)";
+        $db->sql_query($sql);
+    }
+
+    /**
+     * Insère ou met à jour la version applicative en base de données
+     * Utilisé uniquement par les scripts d'installation/upgrade
+     */
+    public function setApplicationVersion($db, $table_prefix, $version): void
+    {
+        $this->setConfigValue($db, $table_prefix, 'version', $version);
+    }
+
+    /**
      * Valide la configuration de base de données
      */
     private function validateDbConfig($config) {

--- a/install/TestManager.php
+++ b/install/TestManager.php
@@ -160,17 +160,20 @@ class TestManager {
             global $table_prefix;
             $tablePrefix = $table_prefix ?? 'ogspy_';
 
-            $autoUpgrade = new AutoUpgradeManager($this->db, $this->logger, $tablePrefix);
+            $autoUpgrade = new AutoUpgradeManager($this->db, $this->logger, $tablePrefix, '9.9.9');
             $migrationManager = new MigrationManager($this->db, $this->logger, $tablePrefix);
 
             $initialVersion = $migrationManager->getCurrentDbVersion();
             echo "  Version initiale: {$initialVersion}\n";
 
+            // Vérifier l'état de la version applicative avant upgrade
+            $this->logApplicationVersionState("BEFORE UPGRADE");
+
             // 4. Exécuter la mise à niveau automatique
             $upgradeResult = $autoUpgrade->checkAndUpgrade();
 
             if ($upgradeResult['status'] !== 'success' && $upgradeResult['status'] !== 'up_to_date') {
-                throw new Exception("Mise à niveau échouée: " . $upgradeResult['message']);
+                throw new Exception("Mise à niveau échouée: " . ($upgradeResult['message'] ?? 'Erreur inconnue'));
             }
 
             // 5. Vérifier que toutes les migrations ont été appliquées
@@ -181,7 +184,17 @@ class TestManager {
                 throw new Exception("Version finale incorrecte: attendue {$expectedVersion}, trouvée {$finalVersion}");
             }
 
-            // 6. Vérifier l'intégrité après mise à niveau
+            // 6. Vérifier l'état de la version applicative après upgrade
+            $this->logApplicationVersionState("AFTER UPGRADE");
+
+            // 7. Vérifier que la version applicative a été mise à jour dans la DB
+            $appVersionInDb = $this->getConfigValue('version');
+            if ($appVersionInDb !== '9.9.9') {
+                throw new Exception("Version applicative incorrecte après upgrade: attendue 9.9.9, trouvée {$appVersionInDb}");
+            }
+            echo "  ✓ Application version verified in database: {$appVersionInDb}\n";
+
+            // 8. Vérifier l'intégrité après mise à niveau
             $this->verifyInstallIntegrity();
 
             $result['details']['initial_version'] = $initialVersion;
@@ -595,5 +608,38 @@ class Migration_20250815002_UpdateTestFeatures {
         }
 
         return $result;
+    }
+
+    /**
+     * Récupère une valeur de la table de configuration
+     */
+    private function getConfigValue($name) {
+        $result = $this->db->sql_query("SELECT value FROM ogspy_config WHERE name = '" . $this->db->sql_escape_string($name) . "'");
+        if ($this->db->sql_numrows($result) > 0) {
+            $row = $this->db->sql_fetch_assoc($result);
+            return $row['value'];
+        }
+        return null;
+    }
+
+    /**
+     * Insère la version applicative en base, uniquement comme le ferait le script d'installation ou d'upgrade
+     */
+    private function insertApplicationVersion($version) {
+        // Utiliser ConfigGenerator pour insérer la version comme le ferait le vrai script
+        $configGenerator = new ConfigGenerator();
+        global $table_prefix;
+        $tablePrefix = $table_prefix ?? 'ogspy_';
+
+        $configGenerator->setApplicationVersion($this->db, $tablePrefix, $version);
+        echo "  Version applicative insérée: {$version}\n";
+    }
+
+    /**
+     * Journalise l'état de la version applicative
+     */
+    private function logApplicationVersionState($stage) {
+        $appVersion = $this->getConfigValue('version');
+        echo "  État de la version applicative ({$stage}): {$appVersion}\n";
     }
 }

--- a/install/index.php
+++ b/install/index.php
@@ -17,6 +17,10 @@ define("INSTALL_IN_PROGRESS", true);
 $installCompleted = file_exists("../config/id.php");
 $installLocked = file_exists("install.lock");
 
+if (is_file("install/version.php")) {
+    require_once "install/version.php";
+}
+
 // Si installation terminée ET verrouillée, bloquer l'accès web
 // SAUF si on affiche l'écran de finalisation
 if ($installCompleted && $installLocked && !isset($_GET['step'])) {
@@ -106,7 +110,7 @@ if ($_POST) {
 
             if ($configGenerator->generateIdFile($dbConfig)) {
                 $success = "Configuration générée avec succès !";
-                // Pas de redirection - la page se rechargera automatiquement et affichera l'étape suivante
+                // Pas de redirection — la page se rechargera automatiquement et affichera l'étape suivante
             }
         }
 
@@ -139,6 +143,12 @@ if ($_POST) {
 
                 if (empty($failed)) {
                     $success = count($successful) . " migration(s) exécutée(s) avec succès !";
+
+                    // Mise à jour de la version OGSpy dans la table config
+                    $configGenerator = new ConfigGenerator();
+                    $configGenerator->setConfigValue($migrationDb, $table_prefix, 'version', $ogspy_version);
+                    $log->info("OGSpy version set to " . $ogspy_version . " in config table.");
+
                 } else {
                     $errors[] = count($failed) . " migration(s) échouée(s)";
                     foreach ($failed as $failedMigration) {
@@ -267,7 +277,7 @@ if ($configExists) {
 <html lang="fr">
 
 <head>
-    <title>Installation OGSpy 4.0</title>
+    <title>Installation OGSpy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="language" content="fr">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -281,7 +291,7 @@ if ($configExists) {
 <div class="container">
     <div class="header">
         <img src="../skin/OGSpy_skin/logos/logo.png" alt="OGSpy" />
-        <h1>Installation OGSpy 4.0</h1>
+        <h1>Installation OGSpy</h1>
     </div>
 
     <div class="content">

--- a/install/schemas/ogspy_init-data.sql
+++ b/install/schemas/ogspy_init-data.sql
@@ -55,8 +55,7 @@ VALUES ('allied', ''),
        ('mail_smtp_password', ''),
        ('num_of_galaxies', '9'),
        ('num_of_systems', '499'),
-       ('speed_uni', '1'),
-       ('version', '4.0.0-dev');
+       ('speed_uni', '1');
 
 
 INSERT INTO `ogspy_group`


### PR DESCRIPTION
The auto-upgrade process now updates the application version in the config table after successful migrations. ConfigGenerator provides new methods for setting config values and the application version. The installer and tests have been updated to verify and set the application version, and the initial SQL data no longer sets a default version.