### PR TITLE
Fix #464 Prefixe perdu par l'installeur

### DIFF
--- a/install/MigrationManager.php
+++ b/install/MigrationManager.php
@@ -33,7 +33,10 @@ class MigrationManager {
      * Initializes the migration tracking table
      */
     private function initMigrationsTable() {
-        $sql = "CREATE TABLE IF NOT EXISTS `{$this->migrations_table}` (
+        // Utiliser le préfixe passé au constructeur au lieu de la config
+        $migrationsTable = $this->table_prefix . 'migrations';
+
+        $sql = "CREATE TABLE IF NOT EXISTS `{$migrationsTable}` (
             `id` INT AUTO_INCREMENT PRIMARY KEY,
             `migration` VARCHAR(255) NOT NULL UNIQUE,
             `executed_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -45,6 +48,9 @@ class MigrationManager {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
 
         $this->db->sql_query($sql);
+
+        // Mettre à jour la propriété migrations_table avec le bon préfixe
+        $this->migrations_table = $migrationsTable;
     }
 
     /**

--- a/install/TestManager.php
+++ b/install/TestManager.php
@@ -33,6 +33,7 @@ class TestManager {
         $results = [
             'install_test' => null,
             'upgrade_test' => null,
+            'table_prefix_test' => null,
             'success' => false,
             'errors' => []
         ];
@@ -57,7 +58,18 @@ class TestManager {
 
                 if ($results['upgrade_test']['success']) {
                     echo "✓ Test de mise à niveau réussi\n\n";
-                    $results['success'] = true;
+
+                    // Test 3: Configuration des préfixes de table
+                    echo "🏷️  Test de configuration des préfixes de table...\n";
+                    $results['table_prefix_test'] = $this->testTablePrefix();
+
+                    if ($results['table_prefix_test']['success']) {
+                        echo "✓ Test de préfixe de table réussi\n\n";
+                        $results['success'] = true;
+                    } else {
+                        echo "✗ Test de préfixe de table échoué\n\n";
+                        $results['errors'][] = $results['table_prefix_test']['error'];
+                    }
                 } else {
                     echo "✗ Test de mise à niveau échoué\n\n";
                     $results['errors'][] = $results['upgrade_test']['error'];
@@ -301,9 +313,9 @@ class TestManager {
     /**
      * Vérifie l'intégrité de l'installation
      */
-    private function verifyInstallIntegrity() {
+    private function verifyInstallIntegrity($tablePrefix = 'ogspy_') {
         // Vérifier que les tables essentielles existent
-        $essentialTables = ['ogspy_user', 'ogspy_config', 'ogspy_migrations'];
+        $essentialTables = [$tablePrefix . 'user', $tablePrefix . 'config', $tablePrefix . 'migrations'];
 
         foreach ($essentialTables as $table) {
             $result = $this->db->sql_query("SHOW TABLES LIKE '{$table}'");
@@ -313,7 +325,7 @@ class TestManager {
         }
 
         // Vérifier que la table de configuration a des données
-        $result = $this->db->sql_query("SELECT COUNT(*) as count FROM ogspy_config");
+        $result = $this->db->sql_query("SELECT COUNT(*) as count FROM {$tablePrefix}config");
         $row = $this->db->sql_fetch_assoc($result);
 
         if ($row['count'] == 0) {
@@ -641,5 +653,93 @@ class Migration_20250815002_UpdateTestFeatures {
     private function logApplicationVersionState($stage) {
         $appVersion = $this->getConfigValue('version');
         echo "  État de la version applicative ({$stage}): {$appVersion}\n";
+    }
+
+    /**
+     * Test avec différents préfixes de table
+     */
+    public function testTablePrefix() {
+        $result = ['success' => false, 'error' => null, 'details' => []];
+
+        // Liste des préfixes de table à tester
+        $tablePrefixes = ['ogspy_', 'ogspy_alt_', 'test_'];
+
+        try {
+            foreach ($tablePrefixes as $prefix) {
+                echo "🏷️  Test avec le préfixe de table: {$prefix}\n";
+
+                // 1. Créer une nouvelle base de test avec le préfixe spécifié
+                $this->testDbName = 'ogspy_test_prefix_' . uniqid();
+                $this->createTestDatabase();
+                $this->switchToTestDatabase();
+
+                // 2. Remplacer le préfixe de table dans les migrations de test
+                $this->replaceTablePrefixInMigrations($prefix);
+
+                // 3. Exécuter les migrations avec le nouveau préfixe
+                $migrationManager = new MigrationManager($this->db, $this->logger, $prefix);
+                $allMigrations = $migrationManager->getAvailableMigrations();
+
+                foreach ($allMigrations as $migration) {
+                    echo "  Exécution migration: {$migration['version']}\n";
+                    $migrationResult = $migrationManager->runMigration($migration);
+
+                    if (!$migrationResult) {
+                        throw new Exception("Migration {$migration['version']} échouée avec le préfixe {$prefix}");
+                    }
+                }
+
+                // 4. Vérifier l'intégrité de l'installation avec le nouveau préfixe
+                $this->verifyInstallIntegrity($prefix);
+
+                // 5. Vérifier que la version DB correspond
+                $dbVersion = $migrationManager->getCurrentDbVersion();
+                $expectedVersion = $this->getLatestMigrationVersion();
+
+                if ($dbVersion !== $expectedVersion) {
+                    throw new Exception("Version DB incorrecte avec le préfixe {$prefix}: attendue {$expectedVersion}, trouvée {$dbVersion}");
+                }
+
+                $result['details'][$prefix] = [
+                    'success' => true,
+                    'version' => $dbVersion,
+                    'migrations' => array_column($allMigrations, 'version')
+                ];
+
+                echo "✓ Test réussi avec le préfixe de table: {$prefix}\n\n";
+            }
+
+            $result['success'] = true;
+
+        } catch (Exception $e) {
+            $result['error'] = $e->getMessage();
+            $this->logger->error("Test de préfixe de table échoué", ['error' => $e->getMessage()]);
+        } finally {
+            // Nettoyage
+            $this->cleanup();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Remplace le préfixe de table dans les fichiers de migration de test
+     */
+    private function replaceTablePrefixInMigrations($newPrefix) {
+        $migrationsPath = __DIR__ . '/migrations/';
+
+        foreach ($this->createdTestMigrations as $migrationFile) {
+            if (file_exists($migrationFile)) {
+                $content = file_get_contents($migrationFile);
+
+                // Remplacer le préfixe de table dans le contenu de la migration
+                $newContent = str_replace('ogspy_', $newPrefix, $content);
+
+                // Écrire le nouveau contenu dans le fichier de migration
+                file_put_contents($migrationFile, $newContent);
+
+                echo "  ✓ Préfixe de table remplacé dans: " . basename($migrationFile) . "\n";
+            }
+        }
     }
 }

--- a/install/TestManager.php
+++ b/install/TestManager.php
@@ -95,6 +95,7 @@ class TestManager {
      */
     public function testFreshInstall() {
         $result = ['success' => false, 'error' => null, 'details' => []];
+        global $table_prefix;
 
         try {
             // 1. Créer une base de test vierge
@@ -104,12 +105,13 @@ class TestManager {
             $this->switchToTestDatabase();
 
             // 3. Créer le MigrationManager maintenant que nous sommes sur la bonne base
-            $migrationManager = new MigrationManager($this->db, $this->logger);
+            $migrationManager = new MigrationManager($this->db, $this->logger,$table_prefix);
 
             // 4. Vérifier qu'aucune table OGSpy n'existe (sauf migrations qui vient d'être créée)
             $existingTables = $this->getOGSpyTables();
             $filteredTables = array_filter($existingTables, function($table) {
-                return !in_array($table, ['ogspy_migrations']);
+               // Exclure toutes les tables de migrations légitimes : ogspy_migrations et custom_migrations
+                return !in_array($table, ['ogspy_migrations', 'custom_migrations']);
             });
 
             if (!empty($filteredTables)) {
@@ -132,7 +134,7 @@ class TestManager {
             }
 
             // 6. Vérifier l'intégrité de l'installation
-            $this->verifyInstallIntegrity();
+            $this->verifyInstallIntegrity($table_prefix);
 
             // 7. Vérifier que la version DB correspond
             $dbVersion = $migrationManager->getCurrentDbVersion();
@@ -207,9 +209,8 @@ class TestManager {
             echo "  ✓ Application version verified in database: {$appVersionInDb}\n";
 
             // 8. Vérifier l'intégrité après mise à niveau
-            $this->verifyInstallIntegrity();
+            $this->verifyInstallIntegrity($tablePrefix);
 
-            $result['details']['initial_version'] = $initialVersion;
             $result['details']['final_version'] = $finalVersion;
             $result['details']['upgrade_result'] = $upgradeResult;
             $result['success'] = true;
@@ -339,7 +340,8 @@ class TestManager {
      * Récupère la version de la dernière migration disponible
      */
     private function getLatestMigrationVersion() {
-        $migrationManager = new MigrationManager($this->db, $this->logger);
+        global $table_prefix;
+        $migrationManager = new MigrationManager($this->db, $this->logger, $table_prefix);
         $allMigrations = $migrationManager->getAvailableMigrations();
 
         if (empty($allMigrations)) {
@@ -626,7 +628,8 @@ class Migration_20250815002_UpdateTestFeatures {
      * Récupère une valeur de la table de configuration
      */
     private function getConfigValue($name) {
-        $result = $this->db->sql_query("SELECT value FROM ogspy_config WHERE name = '" . $this->db->sql_escape_string($name) . "'");
+        global $table_prefix;
+        $result = $this->db->sql_query("SELECT value FROM {$table_prefix}config WHERE name = '" . $this->db->sql_escape_string($name) . "'");
         if ($this->db->sql_numrows($result) > 0) {
             $row = $this->db->sql_fetch_assoc($result);
             return $row['value'];
@@ -634,18 +637,6 @@ class Migration_20250815002_UpdateTestFeatures {
         return null;
     }
 
-    /**
-     * Insère la version applicative en base, uniquement comme le ferait le script d'installation ou d'upgrade
-     */
-    private function insertApplicationVersion($version) {
-        // Utiliser ConfigGenerator pour insérer la version comme le ferait le vrai script
-        $configGenerator = new ConfigGenerator();
-        global $table_prefix;
-        $tablePrefix = $table_prefix ?? 'ogspy_';
-
-        $configGenerator->setApplicationVersion($this->db, $tablePrefix, $version);
-        echo "  Version applicative insérée: {$version}\n";
-    }
 
     /**
      * Journalise l'état de la version applicative
@@ -672,9 +663,6 @@ class Migration_20250815002_UpdateTestFeatures {
                 $this->testDbName = 'ogspy_test_prefix_' . uniqid();
                 $this->createTestDatabase();
                 $this->switchToTestDatabase();
-
-                // 2. Remplacer le préfixe de table dans les migrations de test
-                $this->replaceTablePrefixInMigrations($prefix);
 
                 // 3. Exécuter les migrations avec le nouveau préfixe
                 $migrationManager = new MigrationManager($this->db, $this->logger, $prefix);
@@ -722,24 +710,5 @@ class Migration_20250815002_UpdateTestFeatures {
         return $result;
     }
 
-    /**
-     * Remplace le préfixe de table dans les fichiers de migration de test
-     */
-    private function replaceTablePrefixInMigrations($newPrefix) {
-        $migrationsPath = __DIR__ . '/migrations/';
 
-        foreach ($this->createdTestMigrations as $migrationFile) {
-            if (file_exists($migrationFile)) {
-                $content = file_get_contents($migrationFile);
-
-                // Remplacer le préfixe de table dans le contenu de la migration
-                $newContent = str_replace('ogspy_', $newPrefix, $content);
-
-                // Écrire le nouveau contenu dans le fichier de migration
-                file_put_contents($migrationFile, $newContent);
-
-                echo "  ✓ Préfixe de table remplacé dans: " . basename($migrationFile) . "\n";
-            }
-        }
-    }
 }

--- a/install/index.php
+++ b/install/index.php
@@ -135,7 +135,7 @@ if ($_POST) {
             $migrationDb = sql_db::getInstance($db_host, $db_user, $db_password, $db_database);
 
             if ($migrationDb && $migrationDb->db_connect_id) {
-                $migrationManager = new MigrationManager($migrationDb, $log);
+                $migrationManager = new MigrationManager($migrationDb, $log, $table_prefix);
                 $results = $migrationManager->runPendingMigrations(false);
 
                 $successful = array_filter($results, function($r) { return $r['success']; });
@@ -250,7 +250,7 @@ if ($configExists) {
                 $dbConnected = true;
 
                 // Créer le gestionnaire de migrations avec la connexion directe
-                $migrationManager = new MigrationManager($testDb, $log);
+                $migrationManager = new MigrationManager($testDb, $log, $table_prefix);
                 $pendingMigrations = $migrationManager->getPendingMigrations();
 
                 // Vérifier si un compte administrateur existe déjà

--- a/install/upgrade_cli.php
+++ b/install/upgrade_cli.php
@@ -98,8 +98,9 @@ class UpgradeCLI {
 
         global $db, $log;
         try {
-            $this->migrationManager = new MigrationManager($db, $log);
-            $this->autoUpgrade = new AutoUpgradeManager($db, $log);
+            global $table_prefix; // Ajouter la variable globale table_prefix
+            $this->migrationManager = new MigrationManager($db, $log, $table_prefix ?? 'ogspy_');
+            $this->autoUpgrade = new AutoUpgradeManager($db, $log, $table_prefix ?? 'ogspy_');
         } catch (Exception $e) {
             die("Erreur initialisation classes: " . $e->getMessage() . "\n");
         }
@@ -147,6 +148,9 @@ class UpgradeCLI {
                 break;
             case 'test-performance':
                 $this->testPerformance();
+                break;
+            case 'test-prefix':
+                $this->testTablePrefix();
                 break;
             default:
                 $this->showHelp();
@@ -781,6 +785,45 @@ class UpgradeCLI {
                 exit(1);
             }
 
+
+        } catch (Exception $e) {
+            echo "❌ ERREUR CRITIQUE: " . $e->getMessage() . "\n";
+            exit(1);
+        }
+    }
+
+    /**
+     * Test la configuration des préfixes de table
+     */
+    private function testTablePrefix() {
+        global $db, $log;
+
+        echo "🔍 TEST DE LA CONFIGURATION DES PRÉFIXES DE TABLE\n";
+        echo "===============================================\n\n";
+
+        try {
+            $testManager = new TestManager($db, $log);
+            $result = $testManager->testTablePrefix();
+
+            echo "\n=== RÉSULTAT DU TEST DE PRÉFIXE DE TABLE ===\n";
+
+            if ($result['success']) {
+                echo "✅ TEST DE PRÉFIXE DE TABLE RÉUSSI\n";
+
+                foreach ($result['details'] as $prefix => $details) {
+                    if ($details['success']) {
+                        echo "✓ Préfixe '{$prefix}': RÉUSSI\n";
+                        echo "  Version finale: " . $details['version'] . "\n";
+                        echo "  Migrations exécutées: " . count($details['migrations']) . "\n";
+                    } else {
+                        echo "✗ Préfixe '{$prefix}': ÉCHOUÉ\n";
+                    }
+                }
+            } else {
+                echo "❌ TEST DE PRÉFIXE DE TABLE ÉCHOUÉ\n";
+                echo "✗ Erreur: " . $result['error'] . "\n";
+                exit(1);
+            }
         } catch (Exception $e) {
             echo "❌ ERREUR CRITIQUE: " . $e->getMessage() . "\n";
             exit(1);

--- a/install/upgrade_cli.php
+++ b/install/upgrade_cli.php
@@ -390,7 +390,7 @@ class UpgradeCLI {
         echo "\n";
         echo "🎊 INSTALLATION TERMINÉE AVEC SUCCÈS !\n";
         echo "=====================================\n";
-        echo "✓ OGSpy 4.0 est maintenant prêt à être utilisé\n";
+        echo "✓ OGSpy est maintenant prêt à être utilisé\n";
         echo "✓ Connectez-vous avec: {$adminUser}\n";
         echo "✓ URL d'accès: http://votre-serveur/ogspy/\n";
         echo "\nPour gérer l'installation :\n";


### PR DESCRIPTION
MigrationManager, TestManager, and related install scripts now support configurable table prefixes, improving flexibility for installations with custom table naming. Added automated tests for table prefix configuration and updated CLI to include a test-prefix command.