### PR TITLE
fix: correct IP cast bug in update_session causing login failure

### DIFF
--- a/model/Sessions_Model.php
+++ b/model/Sessions_Model.php
@@ -57,11 +57,10 @@ class Sessions_Model extends Model_Abstract
         $user_id = (int)$user_id;
         $lastvisit = (int)$lastvisit;
         $cookie_id = $this->db->sql_escape_string($cookie_id);
-        $user_ip = (bool)$user_ip;
-
 
         $request = "UPDATE " . TABLE_SESSIONS . " SET `user_id` = " . $user_id . ", `session_lastvisit` = " . $lastvisit . " WHERE `id` = '" . $cookie_id . "'";
-        if ($user_ip) {
+        if ($user_ip !== false) {
+            $user_ip = $this->db->sql_escape_string($user_ip);
             $request .= " and `session_ip` = '" . $user_ip . "'";
         }
         $this->db->sql_query($request);


### PR DESCRIPTION
## Problem

After resetting a user's password directly in the database, login was failing with "Unidentified visitor" even though authentication logs showed the password verification succeeded.

## Root Cause

In `Sessions_Model::update_session()`, the `$user_ip` parameter was cast to `bool` before being used in the SQL `WHERE` clause:

```php
$user_ip = (bool)$user_ip;  // "82.67.34.73" → true
// ...
$request .= " and `session_ip` = '" . $user_ip . "'";
// → WHERE session_ip = '1'  ← never matches the real IP
```

This caused the `UPDATE` to match zero rows, leaving `user_id = 0` in the session. The subsequent `SELECT` in `select_user_data_session()` then found the session row but with no linked user → "Unidentified visitor".

## Fix

Removed the erroneous `(bool)` cast. The IP string is now properly escaped with `sql_escape_string()` only when it is actually provided (i.e. not `false`).

```php
if ($user_ip !== false) {
    $user_ip = $this->db->sql_escape_string($user_ip);
    $request .= " and `session_ip` = '" . $user_ip . "'";
}
```

## Files Changed

- `model/Sessions_Model.php` — `update_session()`